### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ There's some similar dependency injection containers for python (not mentioning 
 .. _`Read the Docs`: http://dic.readthedocs.org/
 .. _`Bottle Dependency Injection`: https://github.com/bottlepy/bottle-inject
 .. _`injector`: https://github.com/alecthomas/injector
-.. |version| image:: https://pypip.in/version/dic/badge.svg?text=version
+.. |version| image:: https://img.shields.io/pypi/v/dic.svg?label=version
     :target: https://pypi.python.org/pypi/dic
 .. |docs| image:: https://readthedocs.org/projects/dic/badge/?version=latest
     :target: https://readthedocs.org/projects/dic/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20dic))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `dic`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.